### PR TITLE
Added "startWith" and "endWith" alias methods to improve chaining with "should"

### DIFF
--- a/chai-string.js
+++ b/chai-string.js
@@ -66,7 +66,7 @@
     return matches === count;
   };
 
-  chai.Assertion.addChainableMethod('startsWith', function (expected) {
+  var startsWithMethodWrapper = function (expected) {
     var actual = this._obj;
 
     return this.assert(
@@ -74,9 +74,12 @@
       'expected ' + this._obj + ' to starts with ' + expected,
       'expected ' + this._obj + ' to not starts with ' + expected
     );
-  });
+  };
 
-  chai.Assertion.addChainableMethod('endsWith', function (expected) {
+  chai.Assertion.addChainableMethod('startsWith', startsWithMethodWrapper);
+  chai.Assertion.addChainableMethod('startWith', startsWithMethodWrapper);
+
+  var endsWithMethodWrapper = function (expected) {
     var actual = this._obj;
 
     return this.assert(
@@ -84,7 +87,10 @@
       'expected ' + this._obj + ' to ends with ' + expected,
       'expected ' + this._obj + ' to not ends with ' + expected
     );
-  });
+  };
+
+  chai.Assertion.addChainableMethod('endsWith', endsWithMethodWrapper);
+  chai.Assertion.addChainableMethod('endWith', endsWithMethodWrapper);
 
   chai.Assertion.addChainableMethod('equalIgnoreCase', function (expected) {
     var actual = this._obj;

--- a/test/test.js
+++ b/test/test.js
@@ -67,6 +67,22 @@
 
     });
 
+    describe('#startWith', function () {
+
+      it('should return true', function () {
+        var str = 'abcdef',
+          prefix = 'abc';
+        str.should.startWith(prefix);
+      });
+
+      it('should return false', function () {
+        var str = 'abcdef',
+          prefix = 'cba';
+        str.should.not.startWith(prefix);
+      });
+
+    });
+
     describe('#endsWith', function () {
 
       it('should return true', function () {
@@ -79,6 +95,22 @@
         var str = 'abcdef',
           suffix = 'fed';
         chai.string.endsWith(str, suffix).should.be.false;
+      });
+
+    });
+
+    describe('#endWith', function () {
+
+      it('should return true', function () {
+        var str = 'abcdef',
+          suffix = 'def';
+        str.should.endWith(suffix);
+      });
+
+      it('should return false', function () {
+        var str = 'abcdef',
+          suffix = 'fed';
+        str.should.not.endWith(suffix);
       });
 
     });


### PR DESCRIPTION
`str.should.startsWith(prefix)` looks strange, since "starts" is grammitcal correct form.

now you can write `str.should.startWith(prefix)`
