### PR TITLE
Support newer (compatible) versions of chai.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "chai": "1.9.1",
+    "chai": "^1.9.1",
     "mocha": "~1.6.0",
     "nodemon": "~0.6.23"
   },
   "dependencies": {
-    "chai": "1.9.1"
+    "chai": "^1.9.1"
   }
 }


### PR DESCRIPTION
There's a new chai in town, 1.10.0, and I'd like to use it with your excellent module chai-string.