### PR TITLE
Add containIgnoreSpaces assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ chai.use(require('chai-string'));
 * endsWith/endWith
 * equalIgnoreCase
 * equalIgnoreSpaces
+* containIgnoreSpaces
 * singleLine
 * reverseOf
 * palindrome
@@ -68,6 +69,12 @@ expect('abcdef').to.equalIgnoreCase('AbCdEf');
 ```javascript
 assert.equalIgnoreSpaces('abcdef', 'a\nb\tc\r d  ef');
 expect('abcdef').to.equalIgnoreSpaces('a\nb\tc\r d  ef');
+```
+
+### containIgnoreSpaces
+```javascript
+assert.containIgnoreSpaces('abcdefgh', 'a\nb\tc\r d  ef');
+expect('abcdefgh').to.containIgnoreSpaces('a\nb\tc\r d  ef');
 ```
 
 ### singleLine

--- a/chai-string.js
+++ b/chai-string.js
@@ -50,6 +50,13 @@
     return str1.replace(/\s/g, '') === str2.replace(/\s/g, '');
   };
 
+  chai.string.containIgnoreSpaces = function (str1, str2) {
+    if (!isString(str1) || !isString(str2)) {
+      return false;
+    }
+    return str1.replace(/\s/g, '').indexOf(str2.replace(/\s/g, '')) > -1;
+  };
+
   chai.string.singleLine = function(str) {
     if (!isString(str)) {
       return false;
@@ -147,6 +154,16 @@
     );
   });
 
+  chai.Assertion.addChainableMethod('containIgnoreSpaces', function (expected) {
+    var actual = this._obj;
+
+    return this.assert(
+      chai.string.containIgnoreSpaces(actual, expected),
+      'expected ' + this._obj + ' to contain ' + expected + ' ignoring spaces',
+      'expected ' + this._obj + ' not to contain ' + expected + ' ignoring spaces'
+    );
+  });
+
   chai.Assertion.addChainableMethod('singleLine', function () {
     var actual = this._obj;
 
@@ -230,6 +247,14 @@
 
   assert.notEqualIgnoreSpaces = function (val, exp, msg) {
     new chai.Assertion(val, msg).to.not.be.equalIgnoreSpaces(exp);
+  };
+
+  assert.containIgnoreSpaces = function (val, exp, msg) {
+    new chai.Assertion(val, msg).to.be.containIgnoreSpaces(exp);
+  };
+
+  assert.notContainIgnoreSpaces = function (val, exp, msg) {
+    new chai.Assertion(val, msg).to.not.be.containIgnoreSpaces(exp);
   };
 
   assert.singleLine = function(val, exp, msg) {

--- a/test/test.js
+++ b/test/test.js
@@ -198,6 +198,35 @@
 
     });
 
+    describe('#containIgnoreSpaces', function () {
+
+      it('should return true', function () {
+        var str1 = '1234abcdef56',
+          str2 = '1234a\nb\tc\r d  ef56';
+        chai.string.containIgnoreSpaces(str1, str2).should.be.true;
+      });
+
+      it('should return true (2)', function () {
+        var str1 = 'abcdef',
+          str2 = 'a\nb\tc\r d  ef';
+        chai.string.containIgnoreSpaces(str1, str2).should.be.true;
+      });
+
+      it('should return false', function () {
+        var str1 = 'abdef',
+          str2 = 'a\nb\tc\r d  ef';
+        chai.string.containIgnoreSpaces(str1, str2).should.be.false;
+      });
+
+      it('should return false (2)', function () {
+        chai.string.containIgnoreSpaces('12', 12).should.be.false;
+      });
+
+      it('should return false (3)', function () {
+        chai.string.containIgnoreSpaces(12, '12').should.be.false;
+      });
+    });
+
     describe('#singleLine', function() {
 
       it('should return true', function() {
@@ -436,6 +465,14 @@
 
       it('.notEqualIgnoreSpaces (3)', function () {
         assert.notEqualIgnoreSpaces(12, '12');
+      });
+
+      it('.containIgnoreSpaces', function () {
+        assert.containIgnoreSpaces(this.str, this.str2);
+      });
+
+      it('.notContainIgnoreSpaces', function () {
+        assert.notContainIgnoreSpaces(this.str, this.str2 + 'g');
       });
 
       it('.singleLine', function() {


### PR DESCRIPTION
Examples:

```javascript
assert.containIgnoreSpaces('abcdefgh', 'a\nb\tc\r d  ef');
expect('abcdefgh').to.containIgnoreSpaces('a\nb\tc\r d  ef');
```
