### PR TITLE
Contains without case

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ assert.containIgnoreSpaces('abcdefgh', 'a\nb\tc\r d  ef');
 expect('abcdefgh').to.containIgnoreSpaces('a\nb\tc\r d  ef');
 ```
 
+### containIgnoreCase
+```javascript
+assert.containIgnoreCase('abcdefgh', 'AbcDefGH'); 
+expect('abcdefgh').to.containIgnoreCase('AbcDefGH');
+```
+
 ### singleLine
 ```javascript
 assert.singleLine('abcdef');

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ expect('abcdefgh').to.containIgnoreSpaces('a\nb\tc\r d  ef');
 ```javascript
 assert.containIgnoreCase('abcdefgh', 'AbcDefGH'); 
 expect('abcdefgh').to.containIgnoreCase('AbcDefGH');
+'abcdef'.should.containIgnoreCase('cDe');
 ```
 
 ### singleLine

--- a/chai-string.js
+++ b/chai-string.js
@@ -57,6 +57,13 @@
     return str1.replace(/\s/g, '').indexOf(str2.replace(/\s/g, '')) > -1;
   };
 
+  chai.string.containIgnoreCase = function (str1, str2) {
+    if (!isString(str1) || !isString(str2)) {
+      return false;
+    }
+    return str1.toLowerCase().indexOf(str2.toLowerCase()) > -1;
+  }
+
   chai.string.singleLine = function(str) {
     if (!isString(str)) {
       return false;
@@ -164,6 +171,16 @@
     );
   });
 
+  chai.Assertion.addChainableMethod('containIgnoreCase', function (expected) {
+    var actual = this._obj;
+
+    return this.assert(
+      chai.string.containIgnoreCase(actual, expected),
+      'expected ' + this._obj + ' to contain ' + expected + ' ignoring case',
+      'expected ' + this._obj + ' not to contain ' + expected + ' ignoring case'
+    );
+  });
+
   chai.Assertion.addChainableMethod('singleLine', function () {
     var actual = this._obj;
 
@@ -256,6 +273,14 @@
   assert.notContainIgnoreSpaces = function (val, exp, msg) {
     new chai.Assertion(val, msg).to.not.be.containIgnoreSpaces(exp);
   };
+
+  assert.containIgnoreCase = function (val, exp, msg) {
+    new chai.Assertion(val, msg).to.be.containIgnoreCase(exp);
+  };
+
+  assert.notContainIgnoreCase = function (val, exp, msg) {
+    new chai.Assertion(val, msg).to.not.be.containIgnoreCase(exp);
+  }; 
 
   assert.singleLine = function(val, exp, msg) {
     new chai.Assertion(val, msg).to.be.singleLine();

--- a/test/test.js
+++ b/test/test.js
@@ -226,6 +226,39 @@
         chai.string.containIgnoreSpaces(12, '12').should.be.false;
       });
     });
+	
+	describe('#containIgnoreCase', function() {
+		
+		it('should return true', function() {
+			var str1 = 'abcdef',
+			  str2 = 'cDe';
+			chai.string.containIgnoreCase(str1, str2).should.be.true;
+		});
+		
+		it('should return true (2)', function() {
+			var str1 = 'abcdef',
+			  str2 = 'AbCdeF';
+			chai.string.containIgnoreCase(str1, str2).should.be.true;
+		});
+		
+		it('should return false', function() {
+			var str1 = 'abcdef',
+			  str2 = 'efg'; 
+			chai.string.containIgnoreCase(str1, str2).should.be.false;
+		});
+		
+		it('should return false (2)', function() {
+			var str1 = '123',
+			  str2 = 123;
+			chai.string.containIgnoreCase(str1, str2).should.be.false;
+		});
+		
+		it('should return false (3)', function() {
+			var str1 = 'abcdef',
+			  str2 = 'zabcd';
+			chai.string.containIgnoreCase(str1, str2).should.be.false;
+		});
+	});
 
     describe('#singleLine', function() {
 

--- a/test/test.js
+++ b/test/test.js
@@ -236,6 +236,10 @@
 		});
 		
 		it('should return true (2)', function() {
+			'abcdef'.should.containIgnoreCase('cDe');
+		});
+		
+		it('should return true (3)', function() {
 			var str1 = 'abcdef',
 			  str2 = 'AbCdeF';
 			chai.string.containIgnoreCase(str1, str2).should.be.true;


### PR DESCRIPTION
Ran into the same problem as issue #10 

Added a `containIgnoreCase` method which simply does an `indexOf > -1` after converting both strings to compare to lower case.